### PR TITLE
Switch from RemindMeBot to UpdateMeBot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -432,11 +432,9 @@ class AutoBot(object):
 
         base_url = 'https://www.reddit.com/message/compose?'
         query = {
-            'to': 'RemindMeBot',
-            'subject': 'Reminder',
-            'message': (u"[{0}]\n\n"
-                        u"NOTE: Don't forget to add the time options after the command such as '1 Day' or '48 hours'. This defaults to 1 day.\n\n"
-                        u"RemindMe!".format(submission.url))
+            'to': 'UpdateMeBot',
+            'subject': 'Subscribe',
+            'message': (u"SubscribeMe! /r/nosleep /u/{0}\n\n".format(str(submission.author)))
         }
 
         # urllib doesn't do well with non-ascii characters


### PR DESCRIPTION
I run the UpdateMeBot that allows people to subscribe to an author in a subreddit and get reminders each time they post. Users can subscribe via PM, but they can also subscribe by posting a public comment with the phrase "SubscribeMe" or "UpdateMe". The method I use to find comments is occasionally a bit flaky, so I try to encourage users to use a PM instead. I've noticed a relatively large number of public comments in the /r/nosleep subreddit, often in reply to this bots stickied comment. So I figured I would make this pull request to change the link over from the RemindMeBot to my bot.