### PR TITLE
Lock the bot series reminder comment

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -448,6 +448,7 @@ class AutoBot(object):
         series_comment = series_message.format(message_url, issues_url)
         comment = submission.reply(series_comment)
         comment.mod.distinguish(sticky=True)
+        comment.mod.lock()
 
 
     def set_submission_flair(self, submission, flair):


### PR DESCRIPTION
Since we updated PRAW, we can now lock the comment the bot posts for series reminders, per issue #78.

Closes #78 