### PR TITLE
Fetch submissions by new()

### DIFF
--- a/autobot/models/__init__.py
+++ b/autobot/models/__init__.py
@@ -1,4 +1,5 @@
 from . import models
 
 Submission = models.Submission
-SubmissionHandler = models.SubmissionHandler
+Activity = models.Activity
+DataStore = models.DataStore


### PR DESCRIPTION
This change implements the changes necessary to fix #112, so that new submissions
are retrieved using the new() endpoint, rather than a backward poll done via
the /search endpoint.

This change splits the code into these behaviors:

1. Fetch new posts using the 'new()' listing, passing 'before' as appropriate
2. Fetch posts using the hour look-behind /search window, in case users marked their posts 'series'
3. Cache user post activity as needed because searching for user posts will be too slow when new() streams are processed, because Reddit search indexing can take 10+ minutes.