### PR TITLE
Setup fly.io deployment

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -1,0 +1,16 @@
+name: Fly Staging Deploy
+on:
+  push:
+    branches: [ flyprod ]
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl -c fly.prod.toml deploy --remote-only
+

--- a/.github/workflows/deploy.staging.yml
+++ b/.github/workflows/deploy.staging.yml
@@ -1,0 +1,16 @@
+name: Fly Staging Deploy
+on:
+  push:
+    branches: [ main ]
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl -c fly.staging.toml deploy --remote-only
+

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 
 # dotenv
 *.env
+*.env.*
 
 # virtualenv
 .venv

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,0 @@
-worker: python3 run_bot.py --forever --interval 120
-clean: python3 clean_keys.py
-modreport: python3 tools/track_mod_activity.py
-on_demand_report: python3 moderation/activity_tracker.py ondemand

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -1,0 +1,23 @@
+# fly.toml file generated for nosleepautobot-prod on 2022-09-05T00:45:59-04:00
+
+app = "nosleepautobot-prod"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[build]
+  builder = "paketobuildpacks/builder:base"
+
+[env]
+  AUTOBOT_POST_TIMELIMIT = "86400"
+  AUTOBOT_ENFORCE_TIMELIMIT = "true"
+  AUTOBOT_SUBREDDIT = "nosleep"
+  AUTOBOT_USER_AGENT = "/r/nosleep AutoBot v20220903 (by /u/SofaAssassin)"
+  DEVELOPMENT_MODE = "false"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[processes]
+  worker = "python3 run_bot.py --forever --interval 30

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,0 +1,25 @@
+# fly.toml file generated for nosleepautobot-staging on 2022-09-04T22:46:52-04:00
+
+app = "nosleepautobot-staging"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[build]
+  builder = "paketobuildpacks/builder:base"
+
+[env]
+  AUTOBOT_POST_TIMELIMIT = "3600"
+  AUTOBOT_ENFORCE_TIMELIMIT = "true"
+  AUTOBOT_SUBREDDIT = "caneles"
+  AUTOBOT_USER_AGENT = "/r/nosleep AutoBot v20220903 (by /u/SofaAssassin)"
+  DEVELOPMENT_MODE = "false"
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[processes]
+  worker = "python3 run_bot.py --forever --interval 30"
+  #modreport = "python3 autobot/tools/track_mod_activity.py"
+  #on_demand_report = "python3 moderation/activity_tracker.py ondemand"


### PR DESCRIPTION
This change sets up `staging` and `prod` level `fly.toml` files and the associated Github Actions workflows for them. It removes the `Procfile` which is what Heroku used.