### PR TITLE
Use correct branch name for prod deploys

### DIFF
--- a/.github/workflows/deploy.prod.yml
+++ b/.github/workflows/deploy.prod.yml
@@ -1,7 +1,7 @@
-name: Fly Staging Deploy
+name: Fly Production Deploy
 on:
   push:
-    branches: [ flyprod ]
+    branches: [ flymetothemoon ]
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
Actually use `flymetothemoon` prod branch