### PR TITLE
Use vector for log shipping

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.env
+*.env.*
+**/*.pyc
+__pycache__
+.git/
+*.swp
+
+.mypy_cache/
+.venv/
+.circleci/
+.github/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 This is a changelog of important/interesting things that go into production releases.
 
-## 2022-09-22
+## 2022-09-20
+
+### Changed
+
+* Use `vector` for shipping logs
+
+## 2022-09-19
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM python:3.10-slim-bullseye
 
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update && apt-get install -y curl
+RUN curl -1sLf 'https://repositories.timber.io/public/vector/cfg/setup/bash.deb.sh' | bash
+RUN apt-get update && apt-get -y upgrade && apt-get install -y vector
 
 RUN mkdir -p /zeus
 WORKDIR /zeus
 COPY . .
+COPY deploy/vector/vector.toml /etc/vector/vector.toml
 
 RUN pip install -r requirements.txt supervisor
 CMD ["supervisord", "-c", "/zeus/supervisor.conf"]

--- a/autobot/config.py
+++ b/autobot/config.py
@@ -17,7 +17,6 @@ class Settings(BaseSettings):
     user_agent: str
     series_flair_name: str = "series"
     redis_url: Annotated[RedisDsn, Field(env="redis_url")]
-    logtail_token: Annotated[str | None, Field(env="logtail_token")] = None
 
     class Config:
         case_sensitive = False

--- a/deploy/vector/vector.toml
+++ b/deploy/vector/vector.toml
@@ -1,0 +1,43 @@
+[api]
+  enabled = true
+  address = "0.0.0.0:8686"
+
+[sources.fly_log_metrics]
+  type = "internal_metrics"
+
+[sources.nats]
+  type = "nats"
+  url = "nats://[fdaa::3]:4223"
+  queue = "${QUEUE-}"
+  subject = "${SUBJECT-logs.>}"
+  auth.strategy = "user_password"
+  auth.user_password.user = "${ORG-personal}"
+  auth.user_password.password = "${ACCESS_TOKEN?}"
+  connection_name = "Fly logs stream"
+
+[transforms.log_json]
+  type = "remap"
+  inputs = ["nats"]
+  source = '''
+  . = parse_json!(.message)
+  '''
+
+[sinks.fly_log_metrics_prometheus]
+  type = "prometheus_exporter" # required
+  inputs = ["fly_log_metrics"] # required
+  address = "0.0.0.0:9598" # required
+  default_namespace = "fly-logs" # optional, no default
+
+[sinks.blackhole]
+  type = "blackhole"
+  inputs = ["log_json"]
+  print_interval_secs = 100000
+
+[sinks.logtail]
+  type = "http"
+  inputs = ["log_json"]
+  uri = "https://in.logtail.com"
+  encoding.codec = "json"
+  auth.strategy = "bearer"
+  auth.token = "${LOGTAIL_TOKEN}"
+

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -14,8 +14,9 @@ processes = []
   AUTOBOT_POST_TIMELIMIT = "86400"
   AUTOBOT_ENFORCE_TIMELIMIT = "true"
   AUTOBOT_SUBREDDIT = "nosleep"
-  AUTOBOT_USER_AGENT = "/r/nosleep AutoBot v20220919 (by /u/SofaAssassin)"
+  AUTOBOT_USER_AGENT = "/r/nosleep AutoBot v20220920 (by /u/SofaAssassin)"
   DEVELOPMENT_MODE = "false"
+  ORG="sofaworks"
 
 [experimental]
   allowed_public_ports = []

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -14,8 +14,9 @@ processes = []
   AUTOBOT_POST_TIMELIMIT = "3600"
   AUTOBOT_ENFORCE_TIMELIMIT = "true"
   AUTOBOT_SUBREDDIT = "caneles"
-  AUTOBOT_USER_AGENT = "/r/nosleep AutoBot v20220919 (by /u/SofaAssassin)"
+  AUTOBOT_USER_AGENT = "/r/nosleep AutoBot v20220920 (by /u/SofaAssassin)"
   DEVELOPMENT_MODE = "false"
+  ORG="sofaworks"
 
 [experimental]
   allowed_public_ports = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-logtail-python==0.1.3
 Mako==1.2.2
 msgpack==1.0.4
 praw==7.6.0

--- a/run_bot.py
+++ b/run_bot.py
@@ -11,8 +11,6 @@ from autobot.autobot import AutoBot
 from autobot.config import Settings
 from autobot.util.messages.templater import MessageBuilder
 
-from logtail import LogtailHandler
-
 import redis
 import structlog
 
@@ -78,11 +76,6 @@ def transform_and_roll_out() -> None:
     )
     log = structlog.get_logger()
     sys.excepthook = uncaught_ex_handler
-
-    if settings.logtail_token:
-        root_log = logging.getLogger()
-        lth = LogtailHandler(source_token=settings.logtail_token)
-        root_log.addHandler(lth)
 
     parser = create_argparser()
     args = parser.parse_args()

--- a/run_report_service.py
+++ b/run_report_service.py
@@ -7,8 +7,6 @@ import sys
 from autobot.config import Settings
 from moderation.activity import ReportService
 
-from logtail import LogtailHandler
-
 import structlog
 
 
@@ -45,11 +43,6 @@ if __name__ == '__main__':
     )
     log = structlog.get_logger()
     cfg = Settings()
-
-    if cfg.logtail_token:
-        root_log = logging.getLogger()
-        lth = LogtailHandler(source_token=cfg.logtail_token)
-        root_log.addHandler(lth)
 
     cd = Path(__file__).resolve().parent
     td = cd / "moderation" / "templates"

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -17,3 +17,9 @@ directory=/zeus
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 command=python3 run_report_service.py
+
+[program:vector]
+directory=/zeus
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+command=vector -c /etc/vector/vector.toml


### PR DESCRIPTION
The `logtail-python` module has been causing problems with dropping/not shipping logs after the bot has been running for a day or two. This changes to using [`vector`](https://vector.dev/) as a logging sidecar for the production bot in fly.io