### PR TITLE
Upgrade Pydantic to 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This is a changelog of important/interesting things that go into production releases.
 
+## 2024-07-20
+
+### Changed
+
+* Upgrade `msgpack` from 1.0.5 to 1.0.8
+* Upgrade `pydantic` from 1.10.11 to 2.8.2
+* Add `pydantic-settings` as dependency (due to move to `pydantic-2.x`)
+* Upgrade `requests` from 2.31.0 to 2.32.3
+* Upgrade `redis` from 4.6.0 to 5.0.7
+* Upgrade `schedule` from 1.2.0 to 1.2.2
+
+
 ## 2023-08-26
 
 ### Changed

--- a/autobot/config.py
+++ b/autobot/config.py
@@ -1,10 +1,14 @@
 from typing import Annotated
 
-from pydantic import BaseSettings, Field, RedisDsn
+from pydantic import Field, RedisDsn
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    development_mode: Annotated[bool, Field(env="development_mode")] = False
+    development_mode: Annotated[
+        bool,
+        Field(validation_alias="development_mode")
+    ] = False
     ignore_older_than: int = 43200
     ignore_old_posts: bool = True
     post_timelimit: int = 86400
@@ -16,10 +20,10 @@ class Settings(BaseSettings):
     subreddit: str
     user_agent: str
     series_flair_name: str = "flair - series"
-    redis_url: Annotated[RedisDsn, Field(env="redis_url")]
-
-    class Config:
-        case_sensitive = False
-        env_prefix = "autobot_"
-        env_file = "autobot.env"
-        env_file_encoding = "utf-8"
+    redis_url: Annotated[RedisDsn, Field(validation_alias="redis_url")]
+    model_config = SettingsConfigDict(
+        case_sensitive=False,
+        env_prefix="autobot_",
+        env_file="autobot.env",
+        env_file_encoding="utf-8"
+    )

--- a/autobot/tests/test_bot.py
+++ b/autobot/tests/test_bot.py
@@ -209,7 +209,7 @@ class TestBotMethods(TestCase):
         mock_sr.display_name = "nosleep"
 
         reddit_mock.return_value.subreddit = lambda _: mock_sr
-        settings = Settings.construct()
+        settings = Settings.model_construct()
         settings.development_mode = True
         settings.user_agent = "hello"
         settings.client_id = "123"
@@ -236,7 +236,7 @@ class TestBotMethods(TestCase):
         mock_sr.display_name = "nosleep"
 
         reddit_mock.return_value.subreddit = lambda _: mock_sr
-        settings = Settings.construct()
+        settings = Settings.model_construct()
         settings.development_mode = True
         settings.user_agent = "hello"
         settings.client_id = "123"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 Mako==1.2.4
 msgpack==1.0.8
 praw==7.7.1
-pydantic==1.10.11
+pydantic==2.8.2
+pydantic-settings==2.3.4
 python-dotenv==1.0.0
 requests==2.32.3
 redis==5.0.7


### PR DESCRIPTION
This is a major version change, so some code had to be changed (mostly via `bump-pydantic` but also some manual changes due to new serializer features).